### PR TITLE
Bugfix coupling fields in pinned commit

### DIFF
--- a/experiments/exp.EXCLAIM_COUPLED.run
+++ b/experiments/exp.EXCLAIM_COUPLED.run
@@ -9,7 +9,7 @@
 #SBATCH --output=LOG.EXCLAIM_COUPLED.%j
 #SBATCH --error=LOG.EXCLAIM_COUPLED.%j
 #SBATCH --time=00:15:00
-#SBATCH --nodes=4
+#SBATCH --nodes=12
 #SBATCH --gpus-per-node=4
 #SBATCH --mem=0
 #SBATCH --exclusive
@@ -284,7 +284,11 @@ if [ "${activate_output}" == "true" ]; then
 fi
 
 # Check that file intervals are not greater than the restart interval
-[ "${ARCHIVE}" == "true" ] && check_file_interval "${atm_namelist}" "${oce_namelist}" "${restart_interval}" || exit
+if [ "${ARCHIVE}" == "true" ]; then 
+	check_file_interval "${atm_namelist}" "${oce_namelist}" "${restart_interval}" ||
+	echo "set file intergvals to less than the restart interval to use the archive function"
+	exit 1
+fi
 
 # ============================================================================
 # Executables

--- a/experiments/exp.EXCLAIM_COUPLED.run
+++ b/experiments/exp.EXCLAIM_COUPLED.run
@@ -283,7 +283,6 @@ if [ "${activate_output}" == "true" ]; then
     done
 fi
 
-export ARCHIVE="true"
 # Check that file intervals are not greater than the restart interval
 if [ "${ARCHIVE}" == "true" ]; then 
 	check_file_interval "${atm_namelist}" "${oce_namelist}" "${restart_interval}" ||

--- a/experiments/exp.EXCLAIM_COUPLED.run
+++ b/experiments/exp.EXCLAIM_COUPLED.run
@@ -283,10 +283,11 @@ if [ "${activate_output}" == "true" ]; then
     done
 fi
 
+export ARCHIVE="true"
 # Check that file intervals are not greater than the restart interval
 if [ "${ARCHIVE}" == "true" ]; then 
 	check_file_interval "${atm_namelist}" "${oce_namelist}" "${restart_interval}" ||
-	echo "set file intergvals to less than the restart interval to use the archive function"
+	echo "set file intervals to less than the restart interval to use the archive function"
 	exit 1
 fi
 

--- a/experiments/namelists.sh
+++ b/experiments/namelists.sh
@@ -128,7 +128,8 @@ coupling:
     #weight_file_name: w_oce2atm.nc
   - <<: [ *oce2atm, *conserv_interp_stack ]
     coupling_period: ${atm_oce_coupling_timestep}
-    field: [surface_velocity_bundle]
+    field: [eastward_sea_water_velocity,
+            northward_sea_water_velocity]
     #weight_file_name: w_riv2oce.nc
   - <<: [ *atm2oce, *spmap_interp_stack ]
     coupling_period: ${atm_oce_coupling_timestep}


### PR DESCRIPTION
The pinned commit uses the old coupling fields.