### PR TITLE
Revert to old coupling fields for pinned commit

### DIFF
--- a/experiments/namelists.sh
+++ b/experiments/namelists.sh
@@ -128,7 +128,8 @@ coupling:
     #weight_file_name: w_oce2atm.nc
   - <<: [ *oce2atm, *conserv_interp_stack ]
     coupling_period: ${atm_oce_coupling_timestep}
-    field: [surface_velocity_bundle]
+    field: [eastward_sea_water_velocity,
+            northward_sea_water_velocity]
     #weight_file_name: w_riv2oce.nc
   - <<: [ *atm2oce, *spmap_interp_stack ]
     coupling_period: ${atm_oce_coupling_timestep}


### PR DESCRIPTION
The pinned commit uses the old coupling fields